### PR TITLE
Copy submit element to preserve __currentPage value

### DIFF
--- a/Resources/Public/JavaScript/ReCAPTCHA.js
+++ b/Resources/Public/JavaScript/ReCAPTCHA.js
@@ -39,5 +39,11 @@ function onReCAPTCHASubmit() {
     while (form.nodeName != "FORM" && form.parentNode) {
         form = form.parentNode;
     }
+    
+    var currentPage = form.createElement('input');
+    currentPage.type = 'hidden';
+    currentPage.name = submitElement.name;
+    currentPage.value = submitElement.value
+    
     form.submit();
 }


### PR DESCRIPTION
As mentioned in #5, the validation is not triggered server side, because of missing `__currentPage ` parameter. The `form.submit();` doesn't send the value of the button.

This change copies the name and value of the button into a hidden input field to preserve the name/value and to get it sent through the request.